### PR TITLE
Add appointment group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [v1.0.11](https://github.com/shore-gmbh/shore-ruby-client/compare/v1.0.10...v1.0.11)
+## [v1.0.13](https://github.com/shore-gmbh/shore-ruby-client/compare/v1.0.12...v1.0.13)
+### Changed
+- AppointmentGroup - new resource, no further action needed
+
+## [v1.0.12](https://github.com/shore-gmbh/shore-ruby-client/compare/v1.0.11...v1.0.12)
 ### Changed
 - Add `#with_meta` to `ClientBase`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## [v1.0.13](https://github.com/shore-gmbh/shore-ruby-client/compare/v1.0.12...v1.0.13)
+## [v1.0.14](https://github.com/shore-gmbh/shore-ruby-client/compare/v1.0.13...v1.0.14)
 ### Changed
 - AppointmentGroup - new resource, no further action needed
+
+## [v1.0.13](https://github.com/shore-gmbh/shore-ruby-client/compare/v1.0.12...v1.0.13)
+### Changed
+- Update Rubocop version
 
 ## [v1.0.12](https://github.com/shore-gmbh/shore-ruby-client/compare/v1.0.11...v1.0.12)
 ### Changed

--- a/lib/shore/v1/appointment_group.rb
+++ b/lib/shore/v1/appointment_group.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative 'client_base'
+
+module Shore
+  module V1
+    class AppointmentGroup < ClientBase
+    end
+  end
+end

--- a/spec/shore/v1/appointment_group_spec.rb
+++ b/spec/shore/v1/appointment_group_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe Shore::V1::AppointmentGroup do
+  include_examples 'shore json api client' do
+    let(:url) { 'https://api.shore.com/v1/appointment_groups' }
+  end
+end


### PR DESCRIPTION
This PR is part of a series of PRs that will enable reminders for courses. This one in particular, simply enables using `AppointmentGroup` in our ruby client.

https://jira.shore.com/browse/RUN-535