### PR TITLE
Fix deprecated warning rails 6

### DIFF
--- a/lib/shore/client_factory.rb
+++ b/lib/shore/client_factory.rb
@@ -13,12 +13,18 @@ module Shore
   module ClientFactory
     extend ActiveSupport::Concern
 
+    unless respond_to?(:module_parent)
+      def self.module_parent
+        parent
+      end
+    end
+
     # Add all of the client classes to a hash keyed to their type
     # (a.k.a. table_name).
     CLIENT_TYPES = Hash[
-      parent.constants.map { |name| parent.const_get(name) }
-            .select { |klass| klass.respond_to?(:table_name) }
-            .map { |klass| [klass.table_name, klass] }
+      module_parent.constants.map { |name| module_parent.const_get(name) }
+                   .select { |klass| klass.respond_to?(:table_name) }
+                   .map { |klass| [klass.table_name, klass] }
     ].freeze
     private_constant :CLIENT_TYPES
 

--- a/lib/shore/version.rb
+++ b/lib/shore/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Shore # :nodoc:
-  VERSION = '1.2.0'
+  VERSION = '1.3.0'
 end


### PR DESCRIPTION
Running on rails 6+ app we get the following message:
`DEPRECATION WARNING: 'Module#parent' has been renamed to 'module_parent'. 'parent' is deprecated and will be removed in Rails 6.1.`.
This PR should fix that and keeps it compatible with apps running on `rails < 6`.