### PR TITLE
remove deprecated method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v1.4.0](https://github.com/shore-gmbh/shore-ruby-client/compare/v1.3.0...v1.4.0)
+### Changed
+- Update dependencies
+- Remove call to parent method, making it compatible with rails 6.1
+
 ## [v1.3.0](https://github.com/shore-gmbh/shore-ruby-client/compare/v1.2.0...v1.3.0)
 ### Changed
 - Update dependencies

--- a/lib/shore/client_factory.rb
+++ b/lib/shore/client_factory.rb
@@ -16,9 +16,8 @@ module Shore
     # Add all of the client classes to a hash keyed to their type
     # (a.k.a. table_name).
 
-    parent_module = respond_to?(:module_parent) ? module_parent : parent
     CLIENT_TYPES = Hash[
-      parent_module.constants.map { |name| parent_module.const_get(name) }
+      module_parent.constants.map { |name| module_parent.const_get(name) }
                    .select { |klass| klass.respond_to?(:table_name) }
                    .map { |klass| [klass.table_name, klass] }
     ].freeze

--- a/shore.gemspec
+++ b/shore.gemspec
@@ -40,7 +40,7 @@ pushes.'
   # Note: this library is undergoing active development. Please update often!
   # https://github.com/chingor13/json_api_client
   spec.add_development_dependency 'bundler', '~> 1.10'
-  spec.add_development_dependency 'coveralls', '~> 0.8'
+  spec.add_development_dependency 'coveralls', '~> 0.8.23'
   spec.add_development_dependency 'pry-byebug', '~> 3.7'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.8'


### PR DESCRIPTION
The `parent` method has been deprecated and will be removed at rails 6.0.1
This pull request updates some development gems and remove the reference to `parent` method. 

https://apidock.com/rails/v6.0.0/Module/parent